### PR TITLE
Ensure that setTimeout doesn't throw error for firefox extensions

### DIFF
--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -56,7 +56,9 @@ export function getNative<T>(
 
 export const nativeSetTimeout =
   typeof window !== 'undefined'
-    ? getNative<typeof window.setTimeout>('setTimeout')
+    ? (getNative<typeof window.setTimeout>('setTimeout').bind(
+        window,
+      ) as typeof window.setTimeout)
     : global.setTimeout;
 
 /**


### PR DESCRIPTION
Whenever you do this kind of angular check for setTimeout, it ends up causing problems in Firefox extensions:

TypeError: 'setTimeout' called on an object that does not implement interface Window

To avoid this you need to bind the setTimeout to the window