### PR TITLE
Revert grid template prs

### DIFF
--- a/.changeset/stale-llamas-divide.md
+++ b/.changeset/stale-llamas-divide.md
@@ -1,5 +1,0 @@
----
-"rrweb-snapshot": patch
----
-
-adds a correction for when chrome passes an incorrect grid-template-area cssText during snapshot

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -64,7 +64,7 @@ export const nativeSetTimeout =
   typeof window !== 'undefined'
     ? (getNative<typeof window.setTimeout>('setTimeout').bind(
         window,
-      ) as typeof window.setTimeout)
+      ) )
     : global.setTimeout;
 
 /**
@@ -159,44 +159,6 @@ export function stringifyStylesheet(s: CSSStyleSheet): string | null {
   }
 }
 
-function replaceChromeGridTemplateAreas(rule: CSSStyleRule): string {
-  const hasGridTemplateInCSSText = rule.cssText.includes('grid-template:');
-  const hasGridTemplateAreaInStyleRules =
-    rule.style.getPropertyValue('grid-template-areas') !== '';
-  const hasGridTemplateAreaInCSSText = rule.cssText.includes(
-    'grid-template-areas:',
-  );
-  if (
-    isCSSStyleRule(rule) &&
-    hasGridTemplateInCSSText &&
-    hasGridTemplateAreaInStyleRules &&
-    !hasGridTemplateAreaInCSSText
-  ) {
-    // chrome does not correctly provide the grid template areas in the rules cssText
-    // e.g. https://bugs.chromium.org/p/chromium/issues/detail?id=1303968
-    // we remove the grid-template rule from the text... so everything from grid-template: to the next semicolon
-    // and then add each grid-template-x rule into the css text because Chrome isn't doing this correctly
-    const parts = rule.cssText
-      .split(';')
-      .filter((s) => !s.includes('grid-template:'))
-      .map((s) => s.trim());
-
-    const gridStyles: string[] = [];
-
-    for (let i = 0; i < rule.style.length; i++) {
-      const styleName = rule.style[i];
-      if (styleName.startsWith('grid-template')) {
-        gridStyles.push(
-          `${styleName}: ${rule.style.getPropertyValue(styleName)}`,
-        );
-      }
-    }
-    parts.splice(parts.length - 1, 0, gridStyles.join('; '));
-    return parts.join('; ');
-  }
-  return rule.cssText;
-}
-
 export function stringifyRule(rule: CSSRule, sheetHref: string | null): string {
   if (isCSSImportRule(rule)) {
     let importStringified;
@@ -221,9 +183,6 @@ export function stringifyRule(rule: CSSRule, sheetHref: string | null): string {
       // Safari does not escape selectors with : properly
       // see https://bugs.webkit.org/show_bug.cgi?id=184604
       ruleStringified = fixSafariColons(ruleStringified);
-    }
-    if (isCSSStyleRule(rule)) {
-      ruleStringified = replaceChromeGridTemplateAreas(rule);
     }
     if (sheetHref) {
       return absolutifyURLs(ruleStringified, sheetHref);

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -62,9 +62,7 @@ export function getNative<T>(
 
 export const nativeSetTimeout =
   typeof window !== 'undefined'
-    ? (getNative<typeof window.setTimeout>('setTimeout').bind(
-        window,
-      ) )
+    ? getNative<typeof window.setTimeout>('setTimeout').bind(window)
     : global.setTimeout;
 
 /**

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -20,7 +20,7 @@ describe('css parser', () => {
     const ast = postcss([plugin]).process(input, {});
     return ast.css;
   }
-  
+
   describe('mediaSelectorPlugin', () => {
     it('selectors without device remain unchanged', () => {
       const cssText =

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -20,7 +20,7 @@ describe('css parser', () => {
     const ast = postcss([plugin]).process(input, {});
     return ast.css;
   }
-
+  
   describe('mediaSelectorPlugin', () => {
     it('selectors without device remain unchanged', () => {
       const cssText =


### PR DESCRIPTION
In an attempt to keep our fork clean, we are going to revert the commits which brought in the original grid template fix (which contains a bug). The hope is that this will make it easier to work with a single PR for upstream and our fork which will contain a modified version of the original fix.

Reverted the following commits:
https://github.com/rrweb-io/rrweb/pull/1396/commits

Note: reverting the changeset commit wasn't working w/ `git revert` so I manually deleted the file in a separate commit.
