### PR TITLE
Added record side logic to still add items in the movedSet if the par…

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -398,9 +398,11 @@ export default class MutationBuffer {
     }
 
     for (const n of this.movedSet) {
+      const parentNode = dom.parentNode(n);
       if (
         isParentRemoved(this.removesSubTreeCache, n, this.mirror) &&
-        !this.movedSet.has(dom.parentNode(n)!)
+        (!this.movedSet.has(parentNode!)) &&
+        (!this.addedSet.has(parentNode!))
       ) {
         continue;
       }

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -401,8 +401,8 @@ export default class MutationBuffer {
       const parentNode = dom.parentNode(n);
       if (
         isParentRemoved(this.removesSubTreeCache, n, this.mirror) &&
-        (!this.movedSet.has(parentNode!)) &&
-        (!this.addedSet.has(parentNode!))
+        !this.movedSet.has(parentNode!) &&
+        !this.addedSet.has(parentNode!)
       ) {
         continue;
       }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -83,7 +83,7 @@ import {
   getPositionsAndIndex,
   uniqueTextMutations,
   StyleSheetMirror,
-  type ResolveTree
+  type ResolveTree,
 } from '../utils';
 import getInjectStyleRules from './styles/inject-style';
 import './styles/style.css';
@@ -1714,7 +1714,7 @@ export class Replayer {
         ids.add(tree.value.node.id);
         if (tree.children && tree.children.length > 1) {
           const res = nodeIdsToBeAdded(tree.children);
-          res.forEach(id => ids.add(id));
+          res.forEach((id) => ids.add(id));
         }
       }
       return ids;

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -83,6 +83,7 @@ import {
   getPositionsAndIndex,
   uniqueTextMutations,
   StyleSheetMirror,
+  type ResolveTree
 } from '../utils';
 import getInjectStyleRules from './styles/inject-style';
 import './styles/style.css';
@@ -1707,6 +1708,18 @@ export class Replayer {
       appendNode(mutation);
     });
 
+    const nodeIdsToBeAdded = (resolveTrees: Array<ResolveTree>) => {
+      const ids = new Set();
+      for (const tree of resolveTrees) {
+        ids.add(tree.value.node.id);
+        if (tree.children && tree.children.length > 1) {
+          const res = nodeIdsToBeAdded(tree.children);
+          res.forEach(id => ids.add(id));
+        }
+      }
+      return ids;
+    };
+
     const startTime = Date.now();
     while (queue.length) {
       // transform queue to resolve tree
@@ -1721,7 +1734,8 @@ export class Replayer {
       }
       for (const tree of resolveTrees) {
         const parent = mirror.getNode(tree.value.parentId);
-        if (!parent) {
+        const ids = nodeIdsToBeAdded(resolveTrees);
+        if (!parent && !ids.has(tree.value.parentId)) {
           this.debug(
             'Drop resolve tree since there is no parent for the root node.',
             tree,

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -354,7 +354,7 @@ export function polyfill(win = window) {
   }
 }
 
-type ResolveTree = {
+export type ResolveTree = {
   value: addedNodeMutation;
   children: ResolveTree[];
   parent: ResolveTree | null;


### PR DESCRIPTION
…ent node is in the addedSet. On playback side when looping through resolveTrees added a check to see if a parent node was being added as part of another resolveTree in the mutation before dropping a resolveTree for parent not found