### PR TITLE
To prevent mv3 extensions from being flagged, inline the Worker used …

### DIFF
--- a/packages/record/vite.config.ts
+++ b/packages/record/vite.config.ts
@@ -1,4 +1,42 @@
 import path from 'path';
 import config from '../../vite.config.default';
 
-export default config(path.resolve(__dirname, 'src/index.ts'), 'rrweb');
+const disableWorkerInlining = process.env.DISABLE_WORKER_INLINING === 'true';
+const makePostcssExternal = process.env.MAKE_POSTCSS_EXTERNAL === 'true';
+
+function modifyCode(code) {
+    if (makePostcssExternal) {
+        // Remove the postcss import
+        code = code.replace(/import\s+.*?"postcss";\s*/g, '');
+    }
+    if (disableWorkerInlining) {
+        // **NOTE** If we ever intend to enable canvas recording, this will need to be removed or modified
+        // Remove the inlined Worker constructor and replace with noop. This code only gets called when canvas
+        // recording is enabled, which we currently do not support enabling.
+        code = code.replace(/new\s+Worker\s*\([^)]*\)/g, 'function(){return{onerror:null,onmessage:null}}');
+    }
+
+    return code;
+}
+
+export default config(
+    path.resolve(__dirname, 'src/index.ts'),
+    'rrweb',
+    {
+        plugins: [
+            {
+                name: '',
+                enforce: 'post',
+                transform(code, id) {
+                    if (!disableWorkerInlining && !makePostcssExternal) return;
+                    if (/\.(js|ts|jsx|tsx)$/.test(id)) {
+                        return {
+                            code: modifyCode(code),
+                            map: null,
+                        };
+                    }
+                }
+            }
+        ]
+    }
+);

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
     "vite.config.defaults.ts",
     "tsconfig.json"
   ],
-  "globalPassThroughEnv": ["PUPPETEER_HEADLESS", "DISABLE_WORKER_INLINING"],
+  "globalPassThroughEnv": ["PUPPETEER_HEADLESS", "DISABLE_WORKER_INLINING", "MAKE_POSTCSS_EXTERNAL"],
   "tasks": {
     "prepublish": {
       "dependsOn": ["^prepublish", "//#references:update"],

--- a/vite.config.default.ts
+++ b/vite.config.default.ts
@@ -2,6 +2,7 @@
 import dts from 'vite-plugin-dts';
 import { copyFileSync } from 'node:fs';
 import { defineConfig, LibraryOptions, LibraryFormats, Plugin } from 'vite';
+import { RollupOptions } from 'rollup';
 import { build, Format } from 'esbuild';
 import { resolve } from 'path';
 import { umdWrapper } from 'esbuild-plugin-umd-wrapper';
@@ -15,6 +16,7 @@ const emptyOutDir = !process.argv.includes('--watch');
  * For chrome extension, we need to disable worker inlining to pass the review.
  */
 const disableWorkerInlining = process.env.DISABLE_WORKER_INLINING === 'true';
+const makePostcssExternal = process.env.MAKE_POSTCSS_EXTERNAL === 'true';
 
 function minifyAndUMDPlugin({
   name,
@@ -114,6 +116,12 @@ export default function (
   options?: { outputDir?: string; fileName?: string; plugins?: Plugin[] },
 ) {
   const { fileName, outputDir: outDir = 'dist', plugins = [] } = options || {};
+  let rollupOptions: RollupOptions = {};
+  if (makePostcssExternal) {
+    rollupOptions = {
+      external: ['postcss']
+    }
+  }
 
   let formats: LibraryFormats[] = ['es', 'cjs'];
 
@@ -139,6 +147,7 @@ export default function (
       minify: false,
 
       sourcemap: true,
+      rollupOptions,
 
       // rollupOptions: {
       //   output: {


### PR DESCRIPTION
…for canvas recording and then modify the Worker contructor to be a noop. I also added some flags/code for externalizing postcss and removing the resulting import. This used to be handled manually.