### PR TITLE
fix: get correct index positions in nested CSS rules for StyleDeclara…

### DIFF
--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -580,6 +580,7 @@ function getNestedCSSRulePositions(rule: CSSRule): number[] {
       );
       const index = rules.indexOf(childRule);
       pos.unshift(index);
+      return recurse(childRule.parentRule, pos);
     } else if (childRule.parentStyleSheet) {
       const rules = Array.from(childRule.parentStyleSheet.cssRules);
       const index = rules.indexOf(childRule);

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -449,10 +449,7 @@ export function getNestedRule(
   if (position.length === 1) {
     return rule;
   } else {
-    return getNestedRule(
-      rule.cssRules,
-      position.slice(1),
-    );
+    return getNestedRule(rule.cssRules, position.slice(1));
   }
 }
 

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -450,8 +450,8 @@ export function getNestedRule(
     return rule;
   } else {
     return getNestedRule(
-      (rule.cssRules[position[1]] as CSSGroupingRule).cssRules,
-      position.slice(2),
+      rule.cssRules,
+      position.slice(1),
     );
   }
 }


### PR DESCRIPTION
…tion events

player would 💥 in the following scenario:
```
@media (min-width: 800px) {
   .rule1 { top: 0px; }
   .rule2 { top: 0px; }
   .rule3 { top: 0px; }
}
````
- site has nested CSS rules (see above)
- at some point `someCSSRule.style.setProperty` is called (this mutation would be a rrweb StyleDeclaration event)

using the example above, i call `rule3.style.setProperty('top', '50px')` on the site to update the css rule style
what happens:
- record side: the StyleDeclaration mutation event is `{ ...index: [2], set: { property: 'top', value: '50px'} }` instead of `index: [0, 2]` (2 is incorrect because it is nested within `@media`)
- replay side: 2 issues
  1. wasn't sure why was `position.slice(2)` was being passed in to `getNestedRule`. in my example, it would just return an empty array
  2. `getNestedRule` is recursively calling `rule.cssRules[position[1]].cssRules` which in my example would be `rule3.cssRules`. rule3 is a CSSStyleRule tho so it wouldn't contain anything in `cssRules`