### PR TITLE
APP-167304 feat: add a resolveAssetUrl hook for host-rewritten image src

### DIFF
--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -6,7 +6,7 @@ import {
   type elementNode,
   type legacyAttributes,
 } from '@rrweb/types';
-import { type tagMap, type BuildCache } from './types';
+import { type tagMap, type BuildCache, type AssetUrlResolver } from './types';
 import {
   isElement,
   Mirror,
@@ -195,9 +195,10 @@ function buildNode(
     doc: Document;
     hackCss: boolean;
     cache: BuildCache;
+    resolveAssetUrl?: AssetUrlResolver;
   },
 ): Node | null {
-  const { doc, hackCss, cache } = options;
+  const { doc, hackCss, cache, resolveAssetUrl } = options;
   switch (n.type) {
     case NodeType.Document:
       return doc.implementation.createDocument(null, '', null);
@@ -324,6 +325,11 @@ function buildNode(
             node.setAttribute(
               'rrweb-original-srcset',
               n.attributes.srcset as string,
+            );
+          } else if (tagName === 'img' && name === 'src' && resolveAssetUrl) {
+            node.setAttribute(
+              name,
+              resolveAssetUrl(value.toString()) ?? value.toString(),
             );
           } else {
             node.setAttribute(name, value.toString());
@@ -455,6 +461,7 @@ export function buildNodeWithSN(
      */
     afterAppend?: (n: Node, id: number) => unknown;
     cache: BuildCache;
+    resolveAssetUrl?: AssetUrlResolver;
   },
 ): Node | null {
   const {
@@ -464,6 +471,7 @@ export function buildNodeWithSN(
     hackCss = true,
     afterAppend,
     cache,
+    resolveAssetUrl,
   } = options;
   /**
    * Add a check to see if the node is already in the mirror. If it is, we can skip the whole process.
@@ -478,7 +486,7 @@ export function buildNodeWithSN(
     // For safety concern, check if the node in mirror is the same as the node we are trying to build
     if (isNodeMetaEqual(meta, n)) return mirror.getNode(n.id);
   }
-  let node = buildNode(n, { doc, hackCss, cache });
+  let node = buildNode(n, { doc, hackCss, cache, resolveAssetUrl });
   if (!node) {
     return null;
   }
@@ -530,6 +538,7 @@ export function buildNodeWithSN(
         hackCss,
         afterAppend,
         cache,
+        resolveAssetUrl,
       });
       if (!childNode) {
         console.warn('Failed to rebuild', childN);
@@ -619,6 +628,7 @@ function rebuild(
     afterAppend?: (n: Node, id: number) => unknown;
     cache: BuildCache;
     mirror: Mirror;
+    resolveAssetUrl?: AssetUrlResolver;
   },
 ): Node | null {
   const {
@@ -628,6 +638,7 @@ function rebuild(
     afterAppend,
     cache,
     mirror = new Mirror(),
+    resolveAssetUrl,
   } = options;
   const node = buildNodeWithSN(n, {
     doc,
@@ -636,6 +647,7 @@ function rebuild(
     hackCss,
     afterAppend,
     cache,
+    resolveAssetUrl,
   });
   visit(mirror, (visitedNode) => {
     if (onVisit) {

--- a/packages/rrweb-snapshot/src/types.ts
+++ b/packages/rrweb-snapshot/src/types.ts
@@ -71,6 +71,11 @@ export type MaskInputFn = (text: string, element: HTMLElement) => string;
 
 export type KeepIframeSrcFn = (src: string) => boolean;
 
+/**
+ * Rewrites an image `src` before it reaches the DOM. Returning undefined leaves it unchanged.
+ */
+export type AssetUrlResolver = (src: string) => string | undefined;
+
 export type BuildCache = {
   stylesWithHoverClass: Map<string, string>;
 };

--- a/packages/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb-snapshot/test/rebuild.test.ts
@@ -72,6 +72,94 @@ describe('rebuild', function () {
     });
   });
 
+  describe('resolveAssetUrl', function () {
+    function buildImg(
+      attributes: Record<string, string>,
+      resolveAssetUrl?: (src: string) => string | undefined,
+    ): HTMLImageElement {
+      return buildNodeWithSN(
+        {
+          id: 1,
+          tagName: 'img',
+          type: NodeType.Element,
+          attributes,
+          childNodes: [],
+        },
+        { doc: document, mirror, hackCss: false, cache, resolveAssetUrl },
+      ) as HTMLImageElement;
+    }
+
+    it('rewrites an img src the host resolves', function () {
+      const node = buildImg({ src: 'custom-scheme:abc123' }, (src) =>
+        src === 'custom-scheme:abc123'
+          ? 'https://cdn.test/abc123.png'
+          : undefined,
+      );
+      expect(node.getAttribute('src')).toBe('https://cdn.test/abc123.png');
+    });
+
+    it('leaves the src unchanged when the resolver returns undefined', function () {
+      const node = buildImg(
+        { src: 'http://example.com/image.png' },
+        () => undefined,
+      );
+      expect(node.getAttribute('src')).toBe('http://example.com/image.png');
+    });
+
+    it('leaves the src unchanged when no resolver is configured', function () {
+      const node = buildImg({ src: 'custom-scheme:abc123' });
+      expect(node.getAttribute('src')).toBe('custom-scheme:abc123');
+    });
+
+    it('does not offer non-src attributes to the resolver', function () {
+      const seen: string[] = [];
+      const node = buildImg({ src: 'a', alt: 'b', title: 'c' }, (src) => {
+        seen.push(src);
+        return undefined;
+      });
+      expect(seen).toEqual(['a']);
+      expect(node.getAttribute('alt')).toBe('b');
+    });
+
+    it('resolves nested images, not only the root node', function () {
+      const root = buildNodeWithSN(
+        {
+          id: 1,
+          tagName: 'div',
+          type: NodeType.Element,
+          attributes: {},
+          childNodes: [
+            {
+              id: 2,
+              tagName: 'span',
+              type: NodeType.Element,
+              attributes: {},
+              childNodes: [
+                {
+                  id: 3,
+                  tagName: 'img',
+                  type: NodeType.Element,
+                  attributes: { src: 'custom-scheme:deep' },
+                  childNodes: [],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          doc: document,
+          mirror,
+          hackCss: false,
+          cache,
+          resolveAssetUrl: () => 'https://cdn.test/deep.png',
+        },
+      ) as HTMLElement;
+      expect(root.querySelector('img')?.getAttribute('src')).toBe(
+        'https://cdn.test/deep.png',
+      );
+    });
+  });
+
   describe('rr_width/rr_height', function () {
     it('rebuild blocked element with correct dimensions', function () {
       const node = buildNodeWithSN(

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -852,6 +852,7 @@ export class Replayer {
       afterAppend,
       cache: this.cache,
       mirror: this.mirror,
+      resolveAssetUrl: this.config.resolveAssetUrl,
     });
     afterAppend(this.iframe.contentDocument, event.data.node.id);
 
@@ -1571,6 +1572,7 @@ export class Replayer {
         skipChild: true,
         hackCss: true,
         cache: this.cache,
+        resolveAssetUrl: this.config.resolveAssetUrl,
         /**
          * caveat: `afterAppend` only gets called on child nodes of target
          * we have to call it again below when this target was added to the DOM
@@ -1865,6 +1867,15 @@ export class Replayer {
                 if (tn) {
                   textarea.appendChild(tn as TNode);
                 }
+              } else if (
+                attributeName === 'src' &&
+                target.nodeName === 'IMG' &&
+                this.config.resolveAssetUrl
+              ) {
+                (target as Element | RRElement).setAttribute(
+                  attributeName,
+                  this.config.resolveAssetUrl(value) ?? value,
+                );
               } else {
                 (target as Element | RRElement).setAttribute(
                   attributeName,

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -4,6 +4,7 @@ import type {
   SlimDOMOptions,
   MaskInputFn,
   MaskTextFn,
+  AssetUrlResolver,
 } from 'rrweb-snapshot';
 import type { IframeManager } from './record/iframe-manager';
 import type { ShadowDomManager } from './record/shadow-dom-manager';
@@ -194,6 +195,11 @@ export type playerConfig = {
         strokeStyle?: string;
       };
   unpackFn?: UnpackFn;
+  /**
+   * Rewrites an image `src` before it is written to the replayed DOM, letting the host
+   * resolve its own reference scheme. Returning undefined leaves the value unchanged.
+   */
+  resolveAssetUrl?: AssetUrlResolver;
   useVirtualDom: boolean;
   logger: {
     log: (...args: Parameters<typeof console.log>) => void;

--- a/packages/rrweb/test/events/asset-src-mutation.ts
+++ b/packages/rrweb/test/events/asset-src-mutation.ts
@@ -1,0 +1,89 @@
+import { EventType, IncrementalSource } from '@rrweb/types';
+import type { eventWithTime } from '@rrweb/types';
+
+const now = Date.now();
+const events: eventWithTime[] = [
+  {
+    type: EventType.DomContentLoaded,
+    data: {},
+    timestamp: now,
+  },
+  {
+    type: EventType.Load,
+    data: {},
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.Meta,
+    data: {
+      href: 'http://localhost',
+      width: 1000,
+      height: 800,
+    },
+    timestamp: now + 100,
+  },
+  // full snapshot: an img already carrying a host-specific src
+  {
+    data: {
+      node: {
+        id: 1,
+        type: 0,
+        childNodes: [
+          { id: 2, name: 'html', type: 1, publicId: '', systemId: '' },
+          {
+            id: 3,
+            type: 2,
+            tagName: 'html',
+            attributes: { lang: 'en' },
+            childNodes: [
+              {
+                id: 4,
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [],
+              },
+              {
+                id: 5,
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [
+                  {
+                    id: 6,
+                    type: 2,
+                    tagName: 'img',
+                    attributes: { src: 'custom-scheme:first' },
+                    childNodes: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      initialOffset: { top: 0, left: 0 },
+    },
+    type: EventType.FullSnapshot,
+    timestamp: now + 100,
+  },
+  // mutation changing the src of the *existing* img node
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Mutation,
+      texts: [],
+      attributes: [
+        {
+          id: 6,
+          attributes: { src: 'custom-scheme:second' },
+        },
+      ],
+      removes: [],
+      adds: [],
+    },
+    timestamp: now + 500,
+  },
+];
+
+export default events;

--- a/packages/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/test/replayer.test.ts
@@ -30,6 +30,7 @@ import adoptedStyleSheetModification from './events/adopted-style-sheet-modifica
 import documentReplacementEvents from './events/document-replacement';
 import hoverInIframeShadowDom from './events/iframe-shadowdom-hover';
 import customElementDefineClass from './events/custom-element-define-class';
+import assetSrcMutationEvents from './events/asset-src-mutation';
 import { ReplayerEvents } from '@rrweb/types';
 
 interface ISuite {
@@ -515,6 +516,54 @@ describe('replayer', function () {
           (element as HTMLIFrameElement)!.contentWindow!.scrollY,
       ),
     ).toEqual(0);
+  });
+
+  it('resolves img src via resolveAssetUrl on both the snapshot and mutation paths', async () => {
+    await page.evaluate(`
+      events = ${JSON.stringify(assetSrcMutationEvents)};
+      const { Replayer } = rrweb;
+      var replayer = new Replayer(events, {
+        resolveAssetUrl: (src) =>
+          src.startsWith('custom-scheme:')
+            ? 'https://cdn.test/' + src.slice('custom-scheme:'.length) + '.png'
+            : undefined,
+      });
+      replayer.pause(200);
+    `);
+    const iframe = await page.$('iframe');
+    const contentDocument = await iframe!.contentFrame()!;
+
+    // rebuild path
+    expect(
+      await contentDocument!.$eval('img', (el: Element) =>
+        el.getAttribute('src'),
+      ),
+    ).toEqual('https://cdn.test/first.png');
+
+    // mutation path: the same node's src changes mid-session
+    await page.evaluate('replayer.pause(600);');
+    await waitForRAF(page);
+    expect(
+      await contentDocument!.$eval('img', (el: Element) =>
+        el.getAttribute('src'),
+      ),
+    ).toEqual('https://cdn.test/second.png');
+  });
+
+  it('leaves img src untouched when no resolveAssetUrl is configured', async () => {
+    await page.evaluate(`
+      events = ${JSON.stringify(assetSrcMutationEvents)};
+      const { Replayer } = rrweb;
+      var replayer = new Replayer(events, {});
+      replayer.pause(600);
+    `);
+    const iframe = await page.$('iframe');
+    const contentDocument = await iframe!.contentFrame()!;
+    expect(
+      await contentDocument!.$eval('img', (el: Element) =>
+        el.getAttribute('src'),
+      ),
+    ).toEqual('custom-scheme:second');
   });
 
   it('can fast forward input events', async () => {


### PR DESCRIPTION
Closes APP-167304. Consumed by the main-ui side in APP-167305.

## Why

Pendo's mobile SDKs stop sending image bytes once the backend already holds the image, and send a short reference instead. The `src` attribute then holds a token rather than an image:

```
src="pendo-asset:<64-char hex hash>"
```

rrweb writes `src` to the DOM exactly as received, so the browser cannot load it and every deduplicated image is broken in playback.

## The hook

```ts
resolveAssetUrl?: (src: string) => string | undefined;
```

Added to `playerConfig`, following `unpackFn?` as the existing precedent for an optional function-typed option with no default. Returning `undefined` leaves the value untouched.

**No Pendo-specific string appears in this patch.** The library learns only that a host may rewrite a `src`; only the consumer knows what `pendo-asset:` means. That keeps the fork closer to upstream and the hook reusable.

## Two interception points, covering different cases

| Point | Covers |
|---|---|
| `rrweb-snapshot/src/rebuild.ts` — `buildNode`'s attribute loop | the initial full snapshot **and** every subtree added mid-session |
| `rrweb/src/replay/index.ts` — the attribute-mutation loop | `src` changed on an `<img>` that already exists |

The first covers `mutation.adds` for free: `appendNode` reaches `buildNode` through `buildNodeWithSN`. The option is threaded through all three `rebuild.ts` functions **and their recursive child call**, so nested images resolve — not only a root node.

The second is genuinely separate. A mid-session `src` change is a raw `setAttribute` with no special-casing and never touches `buildNode`. Patching only the rebuild path looks correct on the first frame and fails silently on the first screen change.

## Considered and rejected: `ReplayPlugin.onBuild`

A plugin could rewrite `img.src` today with no library change at all. Rejected because it fires from `afterAppend`, i.e. *after* the attribute is already in the DOM — the browser starts loading the token, fails, and only then gets the real URL, producing a visible flash. Because mobile emits a full snapshot per draw event, that flash would repeat throughout playback rather than once. It is also never invoked for attribute mutations on existing nodes.

## Test plan

```
cd packages/rrweb-snapshot && yarn test
cd packages/rrweb && yarn test      # needs a built dist
```

* **Rebuild path** (jsdom, `rebuild.test.ts`): a token is rewritten; an ordinary `src` is untouched; a resolver returning `undefined` changes nothing; non-`src` attributes are never offered to the resolver; and a **nested** image resolves.
* **Mutation path** (puppeteer, `replayer.test.ts` plus a new `events/asset-src-mutation.ts` fixture): an `<img>` whose `src` changes mid-session resolves, and with no resolver configured the value is left alone.

Each assertion was checked against the unpatched code first: 3 of 5 rebuild tests and the mutation assertion fail without the change. The remaining ones are guards that correctly pass either way.

Three tests in `replayer.test.ts` fail on this branch — `can handle remote stylesheets` and the two `StyleSheetRule ... on virtual elements` snapshots. All three fail identically on unmodified `pendo-main`; they are pre-existing and unrelated to this change.

## Note for the reviewer

`packages/rrweb/package.json` is named plain `rrweb`, not `@pendo/rrweb`, and no Artifactory publish step exists in this repo — the `@pendo` prefix was added twice in 2024 and then removed. Whoever owns the release process will need to confirm how a new build reaches Artifactory, since main-ui pins `@pendo/rrweb` and aliases `@pendo/beta-rrweb` to a second version of the same artifact. Both pins need to move for the feature to reach every user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnJS6JPQETpxF68n6Mbbw6